### PR TITLE
unbind keybind by default

### DIFF
--- a/src/main/java/de/eydamos/backpack/handler/KeyInputHandler.java
+++ b/src/main/java/de/eydamos/backpack/handler/KeyInputHandler.java
@@ -20,7 +20,7 @@ public class KeyInputHandler {
 
     public static KeyBinding personalBackpack = new KeyBinding(
             Localizations.KEY_PERSONAL,
-            Keyboard.KEY_B,
+            Keyboard.KEY_NONE,
             Localizations.KEY_CATEGORY);
 
     @SubscribeEvent


### PR DESCRIPTION
The goal is to unbind all keys that are not used from the start of the game in the GTNH modpack to avoid all the current keybinds conflict and leave to the user the choice of the keybinds they want.

This one actually conflicts with the other backpack mod