### PR TITLE
Add support for Soulbound enchant

### DIFF
--- a/src/main/java/de/eydamos/backpack/handler/EventHandlerBackpack.java
+++ b/src/main/java/de/eydamos/backpack/handler/EventHandlerBackpack.java
@@ -27,6 +27,7 @@ import de.eydamos.backpack.network.message.MessagePersonalBackpack;
 import de.eydamos.backpack.saves.BackpackSave;
 import de.eydamos.backpack.saves.PlayerSave;
 import de.eydamos.backpack.util.BackpackUtil;
+import de.eydamos.backpack.util.EnchUtils;
 import de.eydamos.backpack.util.NBTItemStackUtil;
 
 public class EventHandlerBackpack {
@@ -106,14 +107,19 @@ public class EventHandlerBackpack {
         PlayerSave playerSave = new PlayerSave(entityPlayer);
         ItemStack backpack = playerSave.getPersonalBackpack();
         if (backpack != null) {
-            event.drops.add(
-                    new EntityItem(
-                            entityPlayer.worldObj,
-                            entityPlayer.posX,
-                            entityPlayer.posY,
-                            entityPlayer.posZ,
-                            backpack));
-            playerSave.setPersonalBackpack(null);
+            if (EnchUtils.isSoulBounded(backpack)
+                    || entityPlayer.getEntityWorld().getGameRules().getGameRuleBooleanValue("keepInventory")) {
+                // Do nothing, let the playerSave object continue to contain the player's backpack.
+            } else {
+                event.drops.add(
+                        new EntityItem(
+                                entityPlayer.worldObj,
+                                entityPlayer.posX,
+                                entityPlayer.posY,
+                                entityPlayer.posZ,
+                                backpack));
+                playerSave.setPersonalBackpack(null);
+            }
         }
     }
 

--- a/src/main/java/de/eydamos/backpack/handler/EventHandlerBackpack.java
+++ b/src/main/java/de/eydamos/backpack/handler/EventHandlerBackpack.java
@@ -107,7 +107,7 @@ public class EventHandlerBackpack {
         PlayerSave playerSave = new PlayerSave(entityPlayer);
         ItemStack backpack = playerSave.getPersonalBackpack();
         if (backpack != null) {
-            if (EnchUtils.isSoulBounded(backpack)
+            if (EnchUtils.isSoulBound(backpack)
                     || entityPlayer.getEntityWorld().getGameRules().getGameRuleBooleanValue("keepInventory")) {
                 // Do nothing, let the playerSave object continue to contain the player's backpack.
             } else {

--- a/src/main/java/de/eydamos/backpack/item/ItemBackpackBase.java
+++ b/src/main/java/de/eydamos/backpack/item/ItemBackpackBase.java
@@ -24,6 +24,7 @@ import de.eydamos.backpack.misc.Constants;
 import de.eydamos.backpack.misc.Localizations;
 import de.eydamos.backpack.saves.BackpackSave;
 import de.eydamos.backpack.util.BackpackUtil;
+import de.eydamos.backpack.util.EnchUtils;
 import de.eydamos.backpack.util.NBTItemStackUtil;
 
 public class ItemBackpackBase extends Item {
@@ -164,7 +165,7 @@ public class ItemBackpackBase extends Item {
 
     @Override
     public boolean isBookEnchantable(ItemStack itemstack1, ItemStack itemstack2) {
-        return false;
+        return EnchUtils.isSoulBook(itemstack2);
     }
 
     @Override

--- a/src/main/java/de/eydamos/backpack/misc/ConfigurationBackpack.java
+++ b/src/main/java/de/eydamos/backpack/misc/ConfigurationBackpack.java
@@ -24,6 +24,7 @@ public class ConfigurationBackpack {
     public static String[] DISALLOW_ITEM_IDS;
     public static String[] FORBIDDEN_DIMENSIONS;
     public static String[] DEFAULT_IDS = {};
+    public static boolean ALLOW_SOULBOUND;
 
     public static boolean NEISupport = false;
     public static boolean PLAY_OPEN_SOUND = false;
@@ -103,6 +104,9 @@ public class ConfigurationBackpack {
         ///
         PLAY_OPEN_SOUND = config.get(Configuration.CATEGORY_GENERAL, "playSound", true, getPlaySoundComment())
                 .getBoolean(true);
+
+        ALLOW_SOULBOUND = config.get(Configuration.CATEGORY_GENERAL, "allowSoulbound", true, getAllowSoulboundComment())
+                .getBoolean(false);
 
         if (config.hasChanged()) {
             config.save();
@@ -215,6 +219,13 @@ public class ConfigurationBackpack {
         return """
                 ##############
                 If true backpack will play opening sound effect
+                ##############""";
+    }
+
+    private static String getAllowSoulboundComment() {
+        return """
+                ##############
+                If true backpack will stay in your backpack slot on death when enchanted with EnderIO soulbound.
                 ##############""";
     }
 }

--- a/src/main/java/de/eydamos/backpack/util/EnchUtils.java
+++ b/src/main/java/de/eydamos/backpack/util/EnchUtils.java
@@ -1,6 +1,7 @@
 package de.eydamos.backpack.util;
 
 import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
@@ -25,15 +26,8 @@ public class EnchUtils {
         return -1;
     }
 
-    public static boolean isSoulBounded(ItemStack stack) {
-        NBTTagList stackEnch = stack.getEnchantmentTagList();
-        if (SOUL_BOUND_ID >= 0 && stackEnch != null) {
-            for (int i = 0; i < stackEnch.tagCount(); i++) {
-                int id = stackEnch.getCompoundTagAt(i).getInteger("id");
-                if (id == SOUL_BOUND_ID) return true;
-            }
-        }
-        return false;
+    public static boolean isSoulBound(ItemStack stack) {
+        return SOUL_BOUND_ID >= 0 && EnchantmentHelper.getEnchantmentLevel(SOUL_BOUND_ID, stack) > 0;
     }
 
     public static boolean isSoulBook(ItemStack book) {
@@ -41,7 +35,7 @@ public class EnchUtils {
             NBTTagCompound bookData = book.stackTagCompound;
             if (bookData.hasKey("StoredEnchantments")) {
                 NBTTagList bookEnch = bookData.getTagList("StoredEnchantments", NBT.TAG_COMPOUND);
-                if (!bookEnch.getCompoundTagAt(1).getBoolean("id")) // only pure soulbook allowed
+                if (bookEnch.tagCount() == 1) // only pure soulbook allowed
                 {
                     int id = bookEnch.getCompoundTagAt(0).getInteger("id");
                     return id == SOUL_BOUND_ID;

--- a/src/main/java/de/eydamos/backpack/util/EnchUtils.java
+++ b/src/main/java/de/eydamos/backpack/util/EnchUtils.java
@@ -1,0 +1,53 @@
+package de.eydamos.backpack.util;
+
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraftforge.common.util.Constants.NBT;
+
+import de.eydamos.backpack.misc.ConfigurationBackpack;
+
+public class EnchUtils {
+
+    // -3 - disabled by config
+    // -1 - enchantment not found
+    private static final int SOUL_BOUND_ID = setSoulBoundID();
+
+    private EnchUtils() {}
+
+    private static int setSoulBoundID() {
+        if (!ConfigurationBackpack.ALLOW_SOULBOUND) return -3;
+
+        for (Enchantment ench : Enchantment.enchantmentsList)
+            if (ench != null && ench.getName().equals("enchantment.enderio.soulBound")) return ench.effectId;
+
+        return -1;
+    }
+
+    public static boolean isSoulBounded(ItemStack stack) {
+        NBTTagList stackEnch = stack.getEnchantmentTagList();
+        if (SOUL_BOUND_ID >= 0 && stackEnch != null) {
+            for (int i = 0; i < stackEnch.tagCount(); i++) {
+                int id = stackEnch.getCompoundTagAt(i).getInteger("id");
+                if (id == SOUL_BOUND_ID) return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean isSoulBook(ItemStack book) {
+        if (SOUL_BOUND_ID >= 0 && book.hasTagCompound()) {
+            NBTTagCompound bookData = book.stackTagCompound;
+            if (bookData.hasKey("StoredEnchantments")) {
+                NBTTagList bookEnch = bookData.getTagList("StoredEnchantments", NBT.TAG_COMPOUND);
+                if (!bookEnch.getCompoundTagAt(1).getBoolean("id")) // only pure soulbook allowed
+                {
+                    int id = bookEnch.getCompoundTagAt(0).getInteger("id");
+                    return id == SOUL_BOUND_ID;
+                }
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
Adds support for EnderIO's soulbound enchant on backpacks, including when they are in the backpack slot. Is implemented in basically the same exact way GTNH Adventurer's backpack mod implements this feature.
Adds config to allow disabling soulbound from working.

Tested on my private server and SP with config enabled, works as expected. Tested with config value disabled in SP, prevents you from enchanting backpack with soulbound, and even a backpack that has soulbound still drops on the ground as expected.

Let me know if you want the config value to default to false.