### PR TITLE
Make Tier 2 craftable (non-GTNH only)

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.25'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.30'
 }
 
 

--- a/src/main/java/de/eydamos/backpack/recipes/RecipeEnhanceBackpack.java
+++ b/src/main/java/de/eydamos/backpack/recipes/RecipeEnhanceBackpack.java
@@ -31,7 +31,7 @@ public class RecipeEnhanceBackpack implements IRecipe {
                     if (!(slotStack.getItem() instanceof ItemBackpackBase)) {
                         return false;
                     }
-                    if (slotStack.getItemDamage() / 100 > 0) {
+                    if (slotStack.getItemDamage() / 100 > 1) {
                         return false;
                     }
                     backpack = slotStack;
@@ -50,7 +50,7 @@ public class RecipeEnhanceBackpack implements IRecipe {
 
         if (backpack != null) {
             result = backpack.copy();
-            result.setItemDamage(result.getItemDamage() + 200);
+            result.setItemDamage(result.getItemDamage() + 100);
         }
 
         return result != null;

--- a/src/main/java/de/eydamos/backpack/recipes/RecipeRecolorBackpack.java
+++ b/src/main/java/de/eydamos/backpack/recipes/RecipeRecolorBackpack.java
@@ -56,7 +56,7 @@ public class RecipeRecolorBackpack implements IRecipe {
             int tier = backpack.getItemDamage() / 100;
             if (tier != 0 && dye.getItem() == Items.leather) {
                 return false;
-            } else if (tier != 2 && dye.getItem() == ItemsBackpack.tannedLeather) {
+            } else if (tier != 1 && tier != 2 && dye.getItem() == ItemsBackpack.tannedLeather) {
                 return false;
             }
 


### PR DESCRIPTION
Changes the enhance backpack recipe to NOT SKIP tier 2. Like this Tier 2 is actually craftable. This does not affect GTNH as GTNH has its own recipes.

### Before

Tier 1 -> Tier 3
![grafik](https://github.com/user-attachments/assets/f582565e-dbad-4d46-8b28-40ee1bfa36bc)

### After

Tier 1 -> Tier 2
![grafik](https://github.com/user-attachments/assets/4ecf73b4-ba5c-4f41-9233-f4d94aa13903)

Tier 2 -> Tier 3
![grafik](https://github.com/user-attachments/assets/e90e6d67-0969-42e3-a6b0-63ad01731f3b)
