### PR TITLE
feat: add adaptive big backpack screen

### DIFF
--- a/src/main/java/de/eydamos/backpack/factory/FactoryBackpackNormal.java
+++ b/src/main/java/de/eydamos/backpack/factory/FactoryBackpackNormal.java
@@ -30,7 +30,7 @@ public class FactoryBackpackNormal extends AbstractFactory<BackpackSave> {
 
         int slotsPerRow = backpack.getSlotsPerRow();
         int inventoryRows = (int) Math.ceil(inventories[1].getSizeInventory() / (float) slotsPerRow);
-        int maxWidth = (Math.max(slotsPerRow, 9)) * SLOT;
+        int maxWidth = slotsPerRow * SLOT;
 
         // set container width (needed for gui)
         container.setWidth(maxWidth + 2 * X_SPACING);
@@ -43,13 +43,13 @@ public class FactoryBackpackNormal extends AbstractFactory<BackpackSave> {
         int remainingSlots = inventories[1].getSizeInventory();
         // backpack inventory
         for (int row = 0; row < inventoryRows; row++) {
-            int cols = remainingSlots - slotsPerRow >= slotsPerRow ? slotsPerRow : remainingSlots;
+            int cols = remainingSlots - slotsPerRow >= 0 ? slotsPerRow : remainingSlots;
             remainingSlots -= cols;
             if (cols * SLOT < maxWidth /* && !hasScrollbar */) {
                 x += (int) Math.round(maxWidth / 2. - cols * SLOT / 2.) + 1;
             }
             for (int col = 0; col < cols; ++col) {
-                container.addSlot(new SlotBackpack(inventories[1], col + row * 9, x, y));
+                container.addSlot(new SlotBackpack(inventories[1], col + row * slotsPerRow, x, y));
                 x += SLOT;
             }
             y += SLOT;
@@ -61,6 +61,9 @@ public class FactoryBackpackNormal extends AbstractFactory<BackpackSave> {
 
         y += 14; // space for label
 
+        int inventorySpaceBefore = (int) Math.round(container.getWidth() / 2. - (SLOT * 9) / 2.);
+        x = inventorySpaceBefore;
+
         // player inventory
         for (int row = 0; row < 3; row++) {
             for (int col = 0; col < 9; col++) {
@@ -68,7 +71,7 @@ public class FactoryBackpackNormal extends AbstractFactory<BackpackSave> {
                 x += SLOT;
             }
             y += SLOT;
-            x = X_SPACING;
+            x = inventorySpaceBefore;
         }
 
         container.addBoundary(Boundaries.INVENTORY_END);
@@ -110,8 +113,10 @@ public class FactoryBackpackNormal extends AbstractFactory<BackpackSave> {
             guiBackpack.addSubPart(guiSlot);
         }
 
+        int inventorySpaceBefore = (int) Math.round(container.getWidth() / 2. - (SLOT * 9) / 2.);
+
         guiBackpack.addSubPart(new Label(X_SPACING, 6, 0x404040, inventories[1].getInventoryName()));
-        guiBackpack.addSubPart(new Label(X_SPACING, textPositionY, 0x404040, "container.inventory"));
+        guiBackpack.addSubPart(new Label(inventorySpaceBefore, textPositionY, 0x404040, "container.inventory"));
 
         return guiBackpack;
     }

--- a/src/main/java/de/eydamos/backpack/factory/FactoryBackpackNormal.java
+++ b/src/main/java/de/eydamos/backpack/factory/FactoryBackpackNormal.java
@@ -20,58 +20,44 @@ import de.eydamos.guiadvanced.subpart.GuiSlot;
 public class FactoryBackpackNormal extends AbstractFactory<BackpackSave> {
 
     @Override
-    public ContainerAdvanced getContainer(BackpackSave backpack, IInventory[] inventories, EntityPlayer entityPlayer) {
-        ContainerAdvanced container;
-        if (inventories[1] instanceof AbstractInventoryBackpack || inventories[1] instanceof InventoryEnderChest) {
-            container = new ContainerAdvanced(inventories, backpack);
-        } else {
-            container = new ContainerAdvanced();
-        }
+    public ContainerAdvanced getContainer(BackpackSave backpack, IInventory[] inventories, EntityPlayer player) {
+        ContainerAdvanced container = (inventories[1] instanceof AbstractInventoryBackpack
+                || inventories[1] instanceof InventoryEnderChest) ? new ContainerAdvanced(inventories, backpack)
+                        : new ContainerAdvanced();
 
         int slotsPerRow = backpack.getSlotsPerRow();
-        int inventoryRows = (int) Math.ceil(inventories[1].getSizeInventory() / (float) slotsPerRow);
+        int totalSlots = inventories[1].getSizeInventory();
+        int rows = (totalSlots + slotsPerRow - 1) / slotsPerRow;
         int maxWidth = slotsPerRow * SLOT;
-
-        // set container width (needed for gui)
-        container.setWidth(maxWidth + 2 * X_SPACING);
-
         int x = X_SPACING;
-        int y = 17; // initial space for label
-
+        int y = 17;
+        container.setWidth(maxWidth + 2 * X_SPACING);
         container.addBoundary(Boundaries.BACKPACK);
 
-        int remainingSlots = inventories[1].getSizeInventory();
-        // backpack inventory
-        for (int row = 0; row < inventoryRows; row++) {
-            int cols = Math.min(remainingSlots, slotsPerRow);
-            remainingSlots -= cols;
-            if (cols * SLOT < maxWidth /* && !hasScrollbar */) {
-                x += (int) Math.round(maxWidth / 2. - cols * SLOT / 2.) + 1;
-            }
-            for (int col = 0; col < cols; ++col) {
-                container.addSlot(new SlotBackpack(inventories[1], col + row * slotsPerRow, x, y));
-                x += SLOT;
+        // Backpack inventory
+        for (int row = 0; row < rows; row++) {
+            int cols = Math.min(slotsPerRow, totalSlots - row * slotsPerRow);
+            int rowX = x + ((cols * SLOT < maxWidth) ? (maxWidth - cols * SLOT) / 2 : 0);
+            for (int col = 0; col < cols; col++) {
+                int index = row * slotsPerRow + col;
+                container.addSlot(new SlotBackpack(inventories[1], index, rowX + col * SLOT, y));
             }
             y += SLOT;
-            x = X_SPACING;
         }
 
         container.addBoundary(Boundaries.BACKPACK_END);
         container.addBoundary(Boundaries.INVENTORY);
 
         y += 14; // space for label
+        x = (container.getWidth() - 9 * SLOT) / 2;
 
-        int inventorySpaceBefore = (int) Math.round(container.getWidth() / 2. - (SLOT * 9) / 2.);
-        x = inventorySpaceBefore;
-
-        // player inventory
+        // Player inventory
         for (int row = 0; row < 3; row++) {
             for (int col = 0; col < 9; col++) {
-                container.addSlot(new Slot(inventories[0], col + row * 9 + 9, x, y));
-                x += SLOT;
+                int index = col + row * 9 + 9;
+                container.addSlot(new Slot(inventories[0], index, x + col * SLOT, y));
             }
             y += SLOT;
-            x = inventorySpaceBefore;
         }
 
         container.addBoundary(Boundaries.INVENTORY_END);
@@ -79,19 +65,14 @@ public class FactoryBackpackNormal extends AbstractFactory<BackpackSave> {
 
         y += 6;
 
-        // hotbar
+        // Hotbar
         for (int col = 0; col < 9; col++) {
-            container.addSlot(new Slot(inventories[0], col, x, y));
-            x += SLOT;
+            container.addSlot(new Slot(inventories[0], col, x + col * SLOT, y));
         }
 
         container.addBoundary(Boundaries.HOTBAR_END);
 
-        y += SLOT;
-        y += 7;
-
-        // set container height (needed for gui)
-        container.setHeight(y);
+        container.setHeight(y + SLOT + 7);
 
         return container;
     }

--- a/src/main/java/de/eydamos/backpack/factory/FactoryBackpackNormal.java
+++ b/src/main/java/de/eydamos/backpack/factory/FactoryBackpackNormal.java
@@ -43,7 +43,7 @@ public class FactoryBackpackNormal extends AbstractFactory<BackpackSave> {
         int remainingSlots = inventories[1].getSizeInventory();
         // backpack inventory
         for (int row = 0; row < inventoryRows; row++) {
-            int cols = remainingSlots - slotsPerRow >= 0 ? slotsPerRow : remainingSlots;
+            int cols = Math.min(remainingSlots, slotsPerRow);
             remainingSlots -= cols;
             if (cols * SLOT < maxWidth /* && !hasScrollbar */) {
                 x += (int) Math.round(maxWidth / 2. - cols * SLOT / 2.) + 1;

--- a/src/main/java/de/eydamos/backpack/misc/Constants.java
+++ b/src/main/java/de/eydamos/backpack/misc/Constants.java
@@ -48,7 +48,6 @@ public class Constants {
         public static final String CUSTOM_NAME = "customName";
         public static final String SIZE = "size";
         public static final String SLOT = "slot";
-        public static final String SLOTS_PER_ROW = "slotsPerRow";
         public static final String INTELLIGENT = "intelligent";
         public static final String TYPE = "type";
         public static final String PERSONAL_BACKPACK_OPEN = "personalBackpackOpen";

--- a/src/main/java/de/eydamos/backpack/network/message/MessageOpenBackpack.java
+++ b/src/main/java/de/eydamos/backpack/network/message/MessageOpenBackpack.java
@@ -76,6 +76,7 @@ public class MessageOpenBackpack implements IMessage, IMessageHandler<MessageOpe
         NBTTagCompound nbtTagCompound = new NBTTagCompound();
         NBTUtil.setString(nbtTagCompound, Constants.NBT.UID, message.uuid);
         NBTUtil.setByte(nbtTagCompound, Constants.NBT.TYPE, message.type);
+        NBTUtil.setInteger(nbtTagCompound, Constants.NBT.SIZE, message.size);
         NBTUtil.setBoolean(nbtTagCompound, Constants.NBT.INTELLIGENT, message.intelligent);
 
         BackpackSave backpackSave = new BackpackSave(nbtTagCompound);

--- a/src/main/java/de/eydamos/backpack/network/message/MessageOpenBackpack.java
+++ b/src/main/java/de/eydamos/backpack/network/message/MessageOpenBackpack.java
@@ -23,7 +23,6 @@ public class MessageOpenBackpack implements IMessage, IMessageHandler<MessageOpe
 
     protected String uuid;
     protected byte type;
-    protected int slotsPerRow = 9;
     protected String name;
     protected boolean customName;
     protected int size;
@@ -38,7 +37,6 @@ public class MessageOpenBackpack implements IMessage, IMessageHandler<MessageOpe
         }
         uuid = backpack.getUUID();
         type = backpack.getType();
-        slotsPerRow = backpack.getSlotsPerRow();
         name = inventory.getInventoryName();
         customName = inventory.hasCustomInventoryName();
         size = inventory.getSizeInventory();
@@ -51,7 +49,6 @@ public class MessageOpenBackpack implements IMessage, IMessageHandler<MessageOpe
         windowId = buffer.readInt();
         uuid = ByteBufUtils.readUTF8String(buffer);
         type = buffer.readByte();
-        slotsPerRow = buffer.readInt();
         name = ByteBufUtils.readUTF8String(buffer);
         customName = buffer.readBoolean();
         size = buffer.readInt();
@@ -63,7 +60,6 @@ public class MessageOpenBackpack implements IMessage, IMessageHandler<MessageOpe
         buffer.writeInt(windowId);
         ByteBufUtils.writeUTF8String(buffer, uuid);
         buffer.writeByte(type);
-        buffer.writeInt(slotsPerRow);
         ByteBufUtils.writeUTF8String(buffer, name);
         buffer.writeBoolean(customName);
         buffer.writeInt(size);
@@ -80,7 +76,6 @@ public class MessageOpenBackpack implements IMessage, IMessageHandler<MessageOpe
         NBTTagCompound nbtTagCompound = new NBTTagCompound();
         NBTUtil.setString(nbtTagCompound, Constants.NBT.UID, message.uuid);
         NBTUtil.setByte(nbtTagCompound, Constants.NBT.TYPE, message.type);
-        NBTUtil.setInteger(nbtTagCompound, Constants.NBT.SLOTS_PER_ROW, message.slotsPerRow);
         NBTUtil.setBoolean(nbtTagCompound, Constants.NBT.INTELLIGENT, message.intelligent);
 
         BackpackSave backpackSave = new BackpackSave(nbtTagCompound);

--- a/src/main/java/de/eydamos/backpack/saves/BackpackSave.java
+++ b/src/main/java/de/eydamos/backpack/saves/BackpackSave.java
@@ -95,9 +95,12 @@ public class BackpackSave extends AbstractSave {
         // Standard backpacks
         if (meta < 17) {
             switch (tier) {
-                case 2: return ConfigurationBackpack.BACKPACK_SLOTS_L;
-                case 1: return ConfigurationBackpack.BACKPACK_SLOTS_M;
-                case 0: return ConfigurationBackpack.BACKPACK_SLOTS_S;
+                case 2:
+                    return ConfigurationBackpack.BACKPACK_SLOTS_L;
+                case 1:
+                    return ConfigurationBackpack.BACKPACK_SLOTS_M;
+                case 0:
+                    return ConfigurationBackpack.BACKPACK_SLOTS_S;
             }
         }
 
@@ -141,45 +144,21 @@ public class BackpackSave extends AbstractSave {
     }
 
     public int getSlotsPerRow() {
-        // 63 is a max number of slots that can fit max mc gui scale
-        // which means 7 rows of 9 slots
-        // so we need to expand max slots per row
-        int slotsPerRow = -1;
-        int leastSlotPerRowToFit = -1;
         int size = getSize();
 
-        if (size > 63) {
-            int minRowsForMaxGuiScale = 1;
-            int maxRowsForMaxGuiScale = 7;
-            int minColumns = 9;
-            int maxColumnsForMaxGuiScale = 19;
+        if (size < 64) {
+            return 9;
+        }
 
-            // let's try to find the perfect fit
-            for (int rows = minRowsForMaxGuiScale; rows <= maxRowsForMaxGuiScale; rows++) {
-                for (int columns = minColumns; columns <= maxColumnsForMaxGuiScale; columns++) {
-                    if (columns * rows == size) {
-                        // this fits the best
-                        slotsPerRow = columns;
-                        break;
-                    } else if (columns * rows > size) {
-                        if (leastSlotPerRowToFit == -1) {
-                            leastSlotPerRowToFit = columns;
-                        }
-                    }
-                }
-            }
-
-            if (slotsPerRow == -1) {
-                slotsPerRow = leastSlotPerRowToFit;
-            }
-
-            if (slotsPerRow == -1) {
-                throw new IllegalArgumentException(
-                        "Impossible state, since max slot count is 128, which fits the 7 * 19 grid");
+        // Search for the best fit
+        for (int columns = 9; columns <= 19; columns++) {
+            int rows = (size + columns - 1) / columns;
+            if (rows <= 7) {
+                return columns;
             }
         }
 
-        return slotsPerRow;
+        throw new IllegalArgumentException("Inventory too large to fit in a 7x19 grid (" + size + " slots)");
     }
 
     @Override

--- a/src/main/java/de/eydamos/backpack/saves/BackpackSave.java
+++ b/src/main/java/de/eydamos/backpack/saves/BackpackSave.java
@@ -81,6 +81,46 @@ public class BackpackSave extends AbstractSave {
             setManualSaving();
 
             setSlotsPerRow(9);
+
+            // 63 is a max number of slots that can fit max mc gui scale
+            // which means 7 rows of 9 slots
+            // so we need to expand max slots per row
+            int slotsPerRow = -1;
+            int leastSlotPerRowToFit = -1;
+
+            if (size > 63) {
+                int minRowsFormaxGuiScale = 1;
+                int maxRowsForMaxGuiScale = 7;
+                int minColumns = 9;
+                int maxColumnsForMaxGuiScale = 19;
+
+                // let's try to find the perfect fit
+                for (int rows = minRowsFormaxGuiScale; rows <= maxRowsForMaxGuiScale; rows++) {
+                    for (int columns = minColumns; columns <= maxColumnsForMaxGuiScale; columns++) {
+                        if (columns * rows == size) {
+                            // this fits the best
+                            slotsPerRow = columns;
+                            break;
+                        } else if (columns * rows > size) {
+                            if (leastSlotPerRowToFit == -1) {
+                                leastSlotPerRowToFit = columns;
+                            }
+                        }
+                    }
+                }
+
+                if (slotsPerRow == -1) {
+                    slotsPerRow = leastSlotPerRowToFit;
+                }
+
+                if (slotsPerRow == -1) {
+                    throw new IllegalArgumentException(
+                            "Impossible state, since max slot count is 128, which fits the 7 * 19 grid");
+                }
+
+                setSlotsPerRow(slotsPerRow);
+            }
+
             setSize(size);
             setType(BackpackUtil.getType(backpack));
             if (!NBTUtil.hasTag(nbtTagCompound, Constants.NBT.INVENTORIES)) {

--- a/src/main/java/de/eydamos/backpack/saves/BackpackSave.java
+++ b/src/main/java/de/eydamos/backpack/saves/BackpackSave.java
@@ -80,47 +80,6 @@ public class BackpackSave extends AbstractSave {
 
             setManualSaving();
 
-            setSlotsPerRow(9);
-
-            // 63 is a max number of slots that can fit max mc gui scale
-            // which means 7 rows of 9 slots
-            // so we need to expand max slots per row
-            int slotsPerRow = -1;
-            int leastSlotPerRowToFit = -1;
-
-            if (size > 63) {
-                int minRowsFormaxGuiScale = 1;
-                int maxRowsForMaxGuiScale = 7;
-                int minColumns = 9;
-                int maxColumnsForMaxGuiScale = 19;
-
-                // let's try to find the perfect fit
-                for (int rows = minRowsFormaxGuiScale; rows <= maxRowsForMaxGuiScale; rows++) {
-                    for (int columns = minColumns; columns <= maxColumnsForMaxGuiScale; columns++) {
-                        if (columns * rows == size) {
-                            // this fits the best
-                            slotsPerRow = columns;
-                            break;
-                        } else if (columns * rows > size) {
-                            if (leastSlotPerRowToFit == -1) {
-                                leastSlotPerRowToFit = columns;
-                            }
-                        }
-                    }
-                }
-
-                if (slotsPerRow == -1) {
-                    slotsPerRow = leastSlotPerRowToFit;
-                }
-
-                if (slotsPerRow == -1) {
-                    throw new IllegalArgumentException(
-                            "Impossible state, since max slot count is 128, which fits the 7 * 19 grid");
-                }
-
-                setSlotsPerRow(slotsPerRow);
-            }
-
             setSize(size);
             setType(BackpackUtil.getType(backpack));
             if (!NBTUtil.hasTag(nbtTagCompound, Constants.NBT.INVENTORIES)) {
@@ -168,15 +127,45 @@ public class BackpackSave extends AbstractSave {
     }
 
     public int getSlotsPerRow() {
-        return NBTUtil.getInteger(nbtTagCompound, Constants.NBT.SLOTS_PER_ROW);
-    }
+        // 63 is a max number of slots that can fit max mc gui scale
+        // which means 7 rows of 9 slots
+        // so we need to expand max slots per row
+        int slotsPerRow = -1;
+        int leastSlotPerRowToFit = -1;
+        int size = getSize();
 
-    public void setSlotsPerRow(int slotsPerRow) {
-        NBTUtil.setInteger(nbtTagCompound, Constants.NBT.SLOTS_PER_ROW, slotsPerRow);
+        if (size > 63) {
+            int minRowsForMaxGuiScale = 1;
+            int maxRowsForMaxGuiScale = 7;
+            int minColumns = 9;
+            int maxColumnsForMaxGuiScale = 19;
 
-        if (!manualSaving) {
-            save();
+            // let's try to find the perfect fit
+            for (int rows = minRowsForMaxGuiScale; rows <= maxRowsForMaxGuiScale; rows++) {
+                for (int columns = minColumns; columns <= maxColumnsForMaxGuiScale; columns++) {
+                    if (columns * rows == size) {
+                        // this fits the best
+                        slotsPerRow = columns;
+                        break;
+                    } else if (columns * rows > size) {
+                        if (leastSlotPerRowToFit == -1) {
+                            leastSlotPerRowToFit = columns;
+                        }
+                    }
+                }
+            }
+
+            if (slotsPerRow == -1) {
+                slotsPerRow = leastSlotPerRowToFit;
+            }
+
+            if (slotsPerRow == -1) {
+                throw new IllegalArgumentException(
+                        "Impossible state, since max slot count is 128, which fits the 7 * 19 grid");
+            }
         }
+
+        return slotsPerRow;
     }
 
     @Override

--- a/src/main/java/de/eydamos/backpack/saves/BackpackSave.java
+++ b/src/main/java/de/eydamos/backpack/saves/BackpackSave.java
@@ -59,24 +59,7 @@ public class BackpackSave extends AbstractSave {
                 NBTItemStackUtil.setString(backpack, Constants.NBT.UID, UID);
             }
 
-            int size = 0;
-            int damage = backpack.getItemDamage();
-            int tier = damage / 100 < 3 ? damage / 100 : 0;
-            int meta = damage % 100;
-            // TODO change BackpackUtil.getSize(tier, color) [multidimensional array build from config]
-            if (meta == 99) { // ender
-                size = 27;
-            } else if (meta < 17 && tier == 2) { // big
-                size = ConfigurationBackpack.BACKPACK_SLOTS_L;
-            } else if (meta < 17 && tier == 1) { // Medium
-                size = ConfigurationBackpack.BACKPACK_SLOTS_M;
-            } else if (meta < 17 && tier == 0) { // normal
-                size = ConfigurationBackpack.BACKPACK_SLOTS_S;
-            } else if (meta == 17 && tier == 0) { // workbench
-                size = 9;
-            } else if (meta == 17 && tier == 2) { // big workbench
-                size = 18;
-            }
+            int size = getSize(backpack);
 
             setManualSaving();
 
@@ -88,6 +71,37 @@ public class BackpackSave extends AbstractSave {
 
             save();
         }
+    }
+
+    private static int getSize(ItemStack backpack) {
+        int damage = backpack.getItemDamage();
+        int tier = damage / 100;
+        int meta = damage % 100;
+
+        // Only accept valid tiers (0, 1, 2); fallback to 0 if invalid
+        if (tier >= 3) tier = 0;
+
+        // Ender backpack
+        if (meta == 99) {
+            return 27;
+        }
+
+        // Workbench variants
+        if (meta == 17) {
+            if (tier == 2) return 18;
+            if (tier == 0) return 9;
+        }
+
+        // Standard backpacks
+        if (meta < 17) {
+            switch (tier) {
+                case 2: return ConfigurationBackpack.BACKPACK_SLOTS_L;
+                case 1: return ConfigurationBackpack.BACKPACK_SLOTS_M;
+                case 0: return ConfigurationBackpack.BACKPACK_SLOTS_S;
+            }
+        }
+
+        return 0;
     }
 
     public String getUUID() {


### PR DESCRIPTION
Rewrites logic for big backpacks, because their content doesn't fit screen in gui mode 'AUTO'.

Only works for **newly created** big backpacks (because it uses NBT-setting :c ). The logic tries to find the most compact grid which will satisfy the size of the backpack

Before: 😢 

![image](https://github.com/user-attachments/assets/faa6c968-4bf2-4682-93c1-5f9c009d92fb)


After: ✨ 

![image](https://github.com/user-attachments/assets/42d54b6e-eee7-40ef-8c4a-ab5a06b2f419)


Extra fixes:
If no grid found that can fully satisfy the size of backpack, it will adapt to the size like this:
![image](https://github.com/user-attachments/assets/18525cd0-9fc3-49b6-b54f-b5588ee77d9a)

