### PR TITLE
Align slots of short inventory rows to the left 

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 // Add your dependencies here
 
 dependencies {
-    api('com.github.GTNewHorizons:NotEnoughItems:2.7.51-GTNH:dev')
+    api('com.github.GTNewHorizons:NotEnoughItems:2.7.77-GTNH:dev')
     api('com.github.GTNewHorizons:inventory-tweaks:1.7.1:dev')
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -151,7 +151,7 @@ modrinthProjectId =
 #       type can be one of [project, version],
 #       and the name is the Modrinth project or version slug/id of the other mod.
 # Example: required-project:fplib;optional-project:gasstation;incompatible-project:gregtech
-# Note: GTNH Mixins is automatically set as a required dependency if usesMixins = true
+# Note: UniMixins is automatically set as a required dependency if usesMixins = true.
 modrinthRelations =
 
 # Publishing to CurseForge requires you to set the CURSEFORGE_TOKEN environment variable to one of your CurseForge API tokens.

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 gtnh.settings.blowdryerTag = 0.2.0
 
 # Human-readable mod name, available for mcmod.info population.
-modName = Backpack Editted for ModdedNetwork
+modName = Backpack Edited for ModdedNetwork
 
 # Case-sensitive identifier string, available for mcmod.info population and used for automatic mixin JSON generation.
 # Conventionally lowercase.

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.38'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.41'
 }
 
 

--- a/src/main/java/de/eydamos/backpack/factory/FactoryBackpackNormal.java
+++ b/src/main/java/de/eydamos/backpack/factory/FactoryBackpackNormal.java
@@ -37,10 +37,9 @@ public class FactoryBackpackNormal extends AbstractFactory<BackpackSave> {
         // Backpack inventory
         for (int row = 0; row < rows; row++) {
             int cols = Math.min(slotsPerRow, totalSlots - row * slotsPerRow);
-            int rowX = x + ((cols * SLOT < maxWidth) ? (maxWidth - cols * SLOT) / 2 : 0);
             for (int col = 0; col < cols; col++) {
                 int index = row * slotsPerRow + col;
-                container.addSlot(new SlotBackpack(inventories[1], index, rowX + col * SLOT, y));
+                container.addSlot(new SlotBackpack(inventories[1], index, x + col * SLOT, y));
             }
             y += SLOT;
         }

--- a/src/main/java/de/eydamos/backpack/misc/ConfigurationBackpack.java
+++ b/src/main/java/de/eydamos/backpack/misc/ConfigurationBackpack.java
@@ -41,18 +41,18 @@ public class ConfigurationBackpack {
         if (ENDER_RECIPE < 0 || ENDER_RECIPE > 1) {
             ENDER_RECIPE = 0;
         }
-        BACKPACK_SLOTS_S = config.get(Configuration.CATEGORY_GENERAL, "backpackSlotsS", 27, getBackpackSlotComment())
-                .getInt();
+        BACKPACK_SLOTS_S = config
+                .get(Configuration.CATEGORY_GENERAL, "backpackSlotsS", 27, getBackpackSlotComment("small")).getInt();
         if (BACKPACK_SLOTS_S < 1 || BACKPACK_SLOTS_S > 128) {
             BACKPACK_SLOTS_S = 27;
         }
-        BACKPACK_SLOTS_M = config.get(Configuration.CATEGORY_GENERAL, "backpackSlotsM", 36, getBackpackSlotComment())
-                .getInt();
+        BACKPACK_SLOTS_M = config
+                .get(Configuration.CATEGORY_GENERAL, "backpackSlotsM", 36, getBackpackSlotComment("medium")).getInt();
         if (BACKPACK_SLOTS_M < 1 || BACKPACK_SLOTS_M > 128) {
             BACKPACK_SLOTS_M = 36;
         }
-        BACKPACK_SLOTS_L = config.get(Configuration.CATEGORY_GENERAL, "backpackSlotsL", 54, getBackpackSlotComment())
-                .getInt();
+        BACKPACK_SLOTS_L = config
+                .get(Configuration.CATEGORY_GENERAL, "backpackSlotsL", 54, getBackpackSlotComment("large")).getInt();
         if (BACKPACK_SLOTS_L < 1 || BACKPACK_SLOTS_L > 128) {
             BACKPACK_SLOTS_L = 54;
         }
@@ -122,12 +122,12 @@ public class ConfigurationBackpack {
                 ##############""";
     }
 
-    private static String getBackpackSlotComment() {
-        return """
-                ##############
-                Number of slots a backpack has
-                valid: integers 1-128
-                ##############""";
+    private static String getBackpackSlotComment(String type) {
+        return "##############\n" + "Number of slots a "
+                + type
+                + " backpack has\n"
+                + "valid: integers 1-128\n"
+                + "##############";
     }
 
     private static String getMaxBackpackAmountComment() {

--- a/src/main/java/de/eydamos/backpack/misc/Constants.java
+++ b/src/main/java/de/eydamos/backpack/misc/Constants.java
@@ -5,7 +5,7 @@ import net.minecraft.util.ResourceLocation;
 public class Constants {
 
     public static final String MOD_ID = "Backpack";
-    public static final String MOD_NAME = "Backpack Editted for ModdedNetwork";
+    public static final String MOD_NAME = "Backpack Edited for ModdedNetwork";
     public static final String MOD_VERSION = "GRADLETOKEN_VERSION";
 
     public static final String DOMAIN = "backpack";


### PR DESCRIPTION
This is related to #14.

With the changes from the mentioned PR and the GTNH config which sets 90 slots for the Big Backpack, this will result in the last row of slots missing one and that aligns it off-grid to the center of the screen. I find this alignment slightly irritating and would prefer it if the slots in the backpack inventory were grid-aligned. This is mostly a preference of course and I'd like to hear if anyone prefers the way it's currently implemented.

Before:
<img width="1280" height="720" alt="2025-08-29_13 15 20" src="https://github.com/user-attachments/assets/ad76a503-ff10-456f-9dc9-33d61a217ea3" />

After:
<img width="1280" height="720" alt="2025-08-29_19 34 09" src="https://github.com/user-attachments/assets/7cebe141-fd6b-4b70-9ff1-c0eb9afbce8e" />

The change here aligns the last row with a missing slot to the left side.

An additional followup can be to maybe add one slot to the Big Backpack in GTNH so that all rows have the same number of slots.

Also included is a fix for a typo in the mod name and extended descriptions for some config options.
