### PR TITLE
Fix item voiding by reducing stack size instead of zeroing

### DIFF
--- a/src/main/java/de/eydamos/backpack/inventory/container/ContainerAdvanced.java
+++ b/src/main/java/de/eydamos/backpack/inventory/container/ContainerAdvanced.java
@@ -259,11 +259,16 @@ public class ContainerAdvanced extends Container {
                     slotStack = slot.getStack();
 
                     if (slotStack == null) {
+                        result = true;
+
                         slot.putStack(sourceStack.copy());
                         slot.onSlotChanged();
-                        sourceStack.stackSize = 0;
-                        result = true;
-                        break;
+
+                        sourceStack.stackSize -= slot.getStack().stackSize;
+
+                        if (sourceStack.stackSize == 0) {
+                            break;
+                        }
                     }
                 }
 


### PR DESCRIPTION
Previously, when moving items to empty slots, the source stack size was set to 0, causing items to be voided if there was more than 1 stack in the Item Stack. Now properly reduces by the actual amount transferred.

Fix GTNewHorizons/GT-New-Horizons-Modpack#21120