### PR TITLE
fix: do not continue bulk crafting with a damageable item that was destroyed

### DIFF
--- a/src/main/java/de/eydamos/backpack/inventory/slot/SlotCraftingAdvanced.java
+++ b/src/main/java/de/eydamos/backpack/inventory/slot/SlotCraftingAdvanced.java
@@ -52,19 +52,22 @@ public class SlotCraftingAdvanced extends SlotCrafting {
                         if (itemstack.getItem().hasContainerItem(itemstack)) {
                             ItemStack containerItem = itemstack.getItem().getContainerItem(itemstack);
 
-                            if (containerItem.isItemStackDamageable()
-                                    && containerItem.getItemDamage() > containerItem.getMaxDamage()) {
-                                MinecraftForge.EVENT_BUS.post(new PlayerDestroyItemEvent(entityPlayer, containerItem));
-                                containerItem = null;
-                            }
-
                             if (containerItem != null) {
-                                if (backpackInventory.getStackInSlot(j) == null) {
-                                    backpackInventory.setInventorySlotContents(j, containerItem);
-                                } else {
-                                    if (!mergeItemStack(containerItem, backpackInventory)) {
-                                        if (!entityPlayer.inventory.addItemStackToInventory(containerItem)) {
-                                            entityPlayer.entityDropItem(containerItem, 0);
+                                if (containerItem.isItemStackDamageable()
+                                        && containerItem.getItemDamage() > containerItem.getMaxDamage()) {
+                                    MinecraftForge.EVENT_BUS
+                                            .post(new PlayerDestroyItemEvent(entityPlayer, containerItem));
+                                    containerItem = null;
+                                }
+
+                                if (containerItem != null) {
+                                    if (backpackInventory.getStackInSlot(j) == null) {
+                                        backpackInventory.setInventorySlotContents(j, containerItem);
+                                    } else {
+                                        if (!mergeItemStack(containerItem, backpackInventory)) {
+                                            if (!entityPlayer.inventory.addItemStackToInventory(containerItem)) {
+                                                entityPlayer.entityDropItem(containerItem, 0);
+                                            }
                                         }
                                     }
                                 }


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21293

Tested with mortars with different durabilities, the bulk crafting using the shift key properly stops, no more crash.