### PR TITLE
Fix crash due to invalid backpack metadata

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 // Add your dependencies here
 
 dependencies {
-    api('com.github.GTNewHorizons:NotEnoughItems:2.8.75-GTNH:dev')
+    api('com.github.GTNewHorizons:NotEnoughItems:2.8.109-GTNH:dev')
     api('com.github.GTNewHorizons:inventory-tweaks:1.7.1:dev')
 }

--- a/src/main/java/de/eydamos/backpack/handler/SaveFileHandler.java
+++ b/src/main/java/de/eydamos/backpack/handler/SaveFileHandler.java
@@ -33,12 +33,12 @@ public class SaveFileHandler {
         if (worldDir == null) return;
 
         backpackDir = new File(worldDir, "backpacks/backpacks");
-        if (!backpackDir.exists()) {
-            backpackDir.mkdirs();
+        if (!backpackDir.isDirectory() && !backpackDir.mkdirs()) {
+            logger.warn("[Backpack] Couldn't create backpack save directory: {}", backpackDir);
         }
         playerDir = new File(worldDir, "backpacks/player");
-        if (!playerDir.exists()) {
-            playerDir.mkdirs();
+        if (!playerDir.isDirectory() && !playerDir.mkdirs()) {
+            logger.warn("[Backpack] Couldn't create player save directory: {}", playerDir);
         }
     }
 
@@ -100,7 +100,7 @@ public class SaveFileHandler {
                 cachedFiles.put(file, (NBTTagCompound) nbtTagCompound.copy());
                 return nbtTagCompound;
             } catch (IOException ioException) {
-                ioException.printStackTrace();
+                logger.warn("[Backpack] Couldn't load data from {}.", file, ioException);
             }
         }
 
@@ -113,8 +113,7 @@ public class SaveFileHandler {
                 nbtTagCompound = CompressedStreamTools.readCompressed(new FileInputStream(file));
                 cachedFiles.put(file, (NBTTagCompound) nbtTagCompound.copy());
             } catch (IOException ioException) {
-                ioException.printStackTrace();
-                logger.warn("[Backpack] Couldn't load data at all.");
+                logger.warn("[Backpack] Couldn't load fallback data from {}.", file, ioException);
             }
         }
 
@@ -131,26 +130,24 @@ public class SaveFileHandler {
         try {
             CompressedStreamTools.writeCompressed(data, new FileOutputStream(fileNew));
 
-            if (fileOld.exists()) {
-                fileOld.delete();
+            if (!deleteIfExists(fileOld)) return;
+
+            if (!renameIfExists(file, fileOld)) return;
+
+            if (!deleteIfExists(file)) return;
+
+            if (!renameIfExists(fileNew, file)) {
+                renameIfExists(fileOld, file);
+                return;
             }
 
-            file.renameTo(fileOld);
-
-            if (file.exists()) {
-                file.delete();
-            }
-
-            fileNew.renameTo(file);
-
-            if (fileNew.exists()) {
-                fileNew.delete();
+            if (fileNew.exists() && !fileNew.delete()) {
+                logger.warn("[Backpack] Couldn't delete temporary save file: {}", fileNew);
             }
 
             cachedFiles.put(file, (NBTTagCompound) data.copy());
         } catch (IOException fileNotFoundException) {
-            fileNotFoundException.printStackTrace();
-            logger.warn("[Backpack] Couldn't save data.");
+            logger.warn("[Backpack] Couldn't save data to {}.", file, fileNotFoundException);
         }
     }
 
@@ -161,19 +158,25 @@ public class SaveFileHandler {
         File fileOld = new File(directory, fileName + ".dat_old");
         File file = new File(directory, fileName + ".dat");
 
-        if (fileOld.exists()) {
-            fileOld.delete();
-        }
-
-        if (file.exists()) {
-            file.delete();
-        }
-
-        if (fileNew.exists()) {
-            fileNew.delete();
-        }
+        deleteIfExists(fileOld);
+        deleteIfExists(file);
+        deleteIfExists(fileNew);
 
         cachedFiles.remove(file);
+    }
+
+    private boolean deleteIfExists(File file) {
+        if (!file.exists()) return true;
+        if (file.delete()) return true;
+        logger.warn("[Backpack] Couldn't delete save file: {}", file);
+        return false;
+    }
+
+    private boolean renameIfExists(File from, File to) {
+        if (!from.exists()) return true;
+        if (from.renameTo(to)) return true;
+        logger.warn("[Backpack] Couldn't rename save file from {} to {}.", from, to);
+        return false;
     }
 
     private boolean isValidUUID(String value) {

--- a/src/main/java/de/eydamos/backpack/handler/SaveFileHandler.java
+++ b/src/main/java/de/eydamos/backpack/handler/SaveFileHandler.java
@@ -5,6 +5,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.UUID;
 
 import net.minecraft.nbt.CompressedStreamTools;
 import net.minecraft.nbt.NBTTagCompound;
@@ -70,12 +71,16 @@ public class SaveFileHandler {
     }
 
     public boolean backpackSaveExists(String UUID) {
+        if (!isValidUUID(UUID)) return false;
+
         File f = new File(backpackDir, UUID + ".dat");
         if (cachedFiles.containsKey(f)) return true;
         return f.exists();
     }
 
     public boolean playerSaveExists(String UUID) {
+        if (!isValidUUID(UUID)) return false;
+
         File f = new File(playerDir, UUID + ".dat");
         if (cachedFiles.containsKey(f)) return true;
         return f.exists();
@@ -83,6 +88,7 @@ public class SaveFileHandler {
 
     public NBTTagCompound load(File directory, String fileName) {
         NBTTagCompound nbtTagCompound = new NBTTagCompound();
+        if (!isValidUUID(fileName)) return nbtTagCompound;
 
         File file = new File(directory, fileName + ".dat");
 
@@ -116,6 +122,8 @@ public class SaveFileHandler {
     }
 
     public void save(NBTTagCompound data, File directory, String fileName) {
+        if (!isValidUUID(fileName)) return;
+
         File fileNew = new File(directory, fileName + ".dat_new");
         File fileOld = new File(directory, fileName + ".dat_old");
         File file = new File(directory, fileName + ".dat");
@@ -147,6 +155,8 @@ public class SaveFileHandler {
     }
 
     public void delete(File directory, String fileName) {
+        if (!isValidUUID(fileName)) return;
+
         File fileNew = new File(directory, fileName + ".dat_new");
         File fileOld = new File(directory, fileName + ".dat_old");
         File file = new File(directory, fileName + ".dat");
@@ -164,5 +174,14 @@ public class SaveFileHandler {
         }
 
         cachedFiles.remove(file);
+    }
+
+    private boolean isValidUUID(String value) {
+        try {
+            UUID.fromString(value);
+            return true;
+        } catch (IllegalArgumentException | NullPointerException e) {
+            return false;
+        }
     }
 }

--- a/src/main/java/de/eydamos/backpack/inventory/container/ContainerAdvanced.java
+++ b/src/main/java/de/eydamos/backpack/inventory/container/ContainerAdvanced.java
@@ -94,6 +94,9 @@ public class ContainerAdvanced extends Container {
     @Override
     public ItemStack transferStackInSlot(EntityPlayer entityPlayer, int slotPos) {
         ItemStack returnStack = null;
+        if (slotPos < 0 || slotPos >= inventorySlots.size()) {
+            return null;
+        }
         Slot slot = (Slot) inventorySlots.get(slotPos);
 
         if (slot != null && slot.getHasStack()) {

--- a/src/main/java/de/eydamos/backpack/inventory/container/ContainerAdvanced.java
+++ b/src/main/java/de/eydamos/backpack/inventory/container/ContainerAdvanced.java
@@ -371,23 +371,32 @@ public class ContainerAdvanced extends Container {
         Map<ContainerSection, List<Slot>> slotRefs = new HashMap<>();
 
         if (boundaries.containsKey(Boundaries.CRAFTING)) {
-            slotRefs.put(ContainerSection.CRAFTING_OUT, inventorySlots.subList(0, 1));
-            slotRefs.put(
+            if (!inventorySlots.isEmpty()) {
+                slotRefs.put(ContainerSection.CRAFTING_OUT, inventorySlots.subList(0, 1));
+            }
+            addContainerSection(
+                    slotRefs,
                     ContainerSection.CRAFTING_IN_PERSISTENT,
-                    inventorySlots.subList(getBoundary(Boundaries.CRAFTING), getBoundary(Boundaries.CRAFTING_END)));
+                    Boundaries.CRAFTING,
+                    Boundaries.CRAFTING_END);
         }
-        slotRefs.put(
-                ContainerSection.INVENTORY,
-                inventorySlots.subList(getBoundary(Boundaries.INVENTORY), getBoundary(Boundaries.HOTBAR_END)));
-        slotRefs.put(
+        addContainerSection(slotRefs, ContainerSection.INVENTORY, Boundaries.INVENTORY, Boundaries.HOTBAR_END);
+        addContainerSection(
+                slotRefs,
                 ContainerSection.INVENTORY_NOT_HOTBAR,
-                inventorySlots.subList(getBoundary(Boundaries.INVENTORY), getBoundary(Boundaries.INVENTORY_END)));
-        slotRefs.put(
-                ContainerSection.INVENTORY_HOTBAR,
-                inventorySlots.subList(getBoundary(Boundaries.HOTBAR), getBoundary(Boundaries.HOTBAR_END)));
-        slotRefs.put(
-                ContainerSection.CHEST,
-                inventorySlots.subList(getBoundary(Boundaries.BACKPACK), getBoundary(Boundaries.BACKPACK_END)));
+                Boundaries.INVENTORY,
+                Boundaries.INVENTORY_END);
+        addContainerSection(slotRefs, ContainerSection.INVENTORY_HOTBAR, Boundaries.HOTBAR, Boundaries.HOTBAR_END);
+        addContainerSection(slotRefs, ContainerSection.CHEST, Boundaries.BACKPACK, Boundaries.BACKPACK_END);
         return slotRefs;
+    }
+
+    private void addContainerSection(Map<ContainerSection, List<Slot>> slotRefs, ContainerSection section,
+            Boundaries startBoundary, Boundaries endBoundary) {
+        int start = getBoundary(startBoundary);
+        int end = getBoundary(endBoundary);
+        if (start >= 0 && start <= end && end <= inventorySlots.size()) {
+            slotRefs.put(section, inventorySlots.subList(start, end));
+        }
     }
 }

--- a/src/main/java/de/eydamos/backpack/inventory/container/ContainerPersonalSlot.java
+++ b/src/main/java/de/eydamos/backpack/inventory/container/ContainerPersonalSlot.java
@@ -8,7 +8,7 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
 
 import de.eydamos.backpack.inventory.AbstractInventoryBackpack;
-import de.eydamos.backpack.inventory.ISaveableInventory;
+import de.eydamos.backpack.inventory.InventoryBackpackSlot;
 import de.eydamos.backpack.inventory.InventoryPickup;
 import de.eydamos.backpack.saves.BackpackSave;
 import de.eydamos.backpack.saves.PlayerSave;
@@ -22,7 +22,7 @@ public class ContainerPersonalSlot extends ContainerAdvanced {
 
     protected final InventoryPickup inventoryPickup;
 
-    public ContainerPersonalSlot(AbstractInventoryBackpack slotInventory, InventoryPickup pickupInventory) {
+    public ContainerPersonalSlot(AbstractInventoryBackpack<?> slotInventory, InventoryPickup pickupInventory) {
         super(slotInventory);
         slotInventory.setEventHandler(this);
         inventoryPickup = pickupInventory;
@@ -50,8 +50,8 @@ public class ContainerPersonalSlot extends ContainerAdvanced {
     @Override
     public void onContainerClosed(EntityPlayer entityPlayer) {
         if (BackpackUtil.isServerSide(entityPlayer.worldObj)) {
-            if (inventory instanceof ISaveableInventory) {
-                ((ISaveableInventory) inventory).writeToNBT(new PlayerSave(entityPlayer));
+            if (inventory instanceof InventoryBackpackSlot) {
+                ((InventoryBackpackSlot) inventory).writeToNBT(new PlayerSave(entityPlayer));
             }
         }
         inventory.closeInventory();

--- a/src/main/java/de/eydamos/backpack/inventory/container/ContainerPersonalSlot.java
+++ b/src/main/java/de/eydamos/backpack/inventory/container/ContainerPersonalSlot.java
@@ -56,6 +56,7 @@ public class ContainerPersonalSlot extends ContainerAdvanced {
         }
         inventory.closeInventory();
         inventoryPickup.closeInventory();
+        super.onContainerClosed(entityPlayer);
     }
 
     public IInventory getInventoryPickup() {

--- a/src/main/java/de/eydamos/backpack/inventory/container/ContainerWorkbenchBackpack.java
+++ b/src/main/java/de/eydamos/backpack/inventory/container/ContainerWorkbenchBackpack.java
@@ -62,7 +62,7 @@ public class ContainerWorkbenchBackpack extends ContainerAdvanced {
 
     @Override
     public ItemStack slotClick(int slotIndex, int mouseButton, int modifier, EntityPlayer player) {
-        Slot slot = slotIndex < 0 ? null : (Slot) inventorySlots.get(slotIndex);
+        Slot slot = slotIndex < 0 || slotIndex >= inventorySlots.size() ? null : (Slot) inventorySlots.get(slotIndex);
         if (slot instanceof SlotPhantom) {
             if (slot.inventory == recipes) {
                 if (BackpackUtil.isServerSide(player.worldObj)) {

--- a/src/main/java/de/eydamos/backpack/network/message/MessageBackpackInfoRequest.java
+++ b/src/main/java/de/eydamos/backpack/network/message/MessageBackpackInfoRequest.java
@@ -1,13 +1,21 @@
 package de.eydamos.backpack.network.message;
 
+import java.util.UUID;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
+import cpw.mods.fml.common.network.ByteBufUtils;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;
 import de.eydamos.backpack.Backpack;
+import de.eydamos.backpack.inventory.container.ContainerAdvanced;
 import de.eydamos.backpack.misc.Constants;
 import de.eydamos.backpack.saves.BackpackSave;
+import de.eydamos.backpack.saves.PlayerSave;
+import de.eydamos.backpack.util.BackpackUtil;
 import io.netty.buffer.ByteBuf;
 
 /**
@@ -25,18 +33,21 @@ public class MessageBackpackInfoRequest implements IMessage, IMessageHandler<Mes
 
     @Override
     public void fromBytes(ByteBuf buf) {
-        int length = buf.readInt();
-        this.backpackUUID = new String(buf.readBytes(length).array());
+        backpackUUID = ByteBufUtils.readUTF8String(buf);
     }
 
     @Override
     public void toBytes(ByteBuf buf) {
-        buf.writeInt(backpackUUID.length());
-        buf.writeBytes(backpackUUID.getBytes());
+        ByteBufUtils.writeUTF8String(buf, backpackUUID);
     }
 
     @Override
     public IMessage onMessage(MessageBackpackInfoRequest message, MessageContext ctx) {
+        EntityPlayerMP player = ctx.getServerHandler().playerEntity;
+        if (!isValidUUID(message.backpackUUID) || !canRequestBackpackInfo(player, message.backpackUUID)) {
+            return null;
+        }
+
         NBTTagCompound backpack = Backpack.saveFileHandler.loadBackpack(message.backpackUUID);
 
         BackpackSave backpackSave = new BackpackSave(backpack);
@@ -45,5 +56,33 @@ public class MessageBackpackInfoRequest implements IMessage, IMessageHandler<Mes
         int total = backpackSave.getSize();
 
         return new MessageBackpackInfo(message.backpackUUID, used, total);
+    }
+
+    private boolean canRequestBackpackInfo(EntityPlayerMP player, String uuid) {
+        for (ItemStack stack : player.inventory.mainInventory) {
+            if (BackpackUtil.UUIDEquals(stack, uuid)) return true;
+        }
+        for (ItemStack stack : player.inventory.armorInventory) {
+            if (BackpackUtil.UUIDEquals(stack, uuid)) return true;
+        }
+
+        ItemStack personalBackpack = new PlayerSave(player).getPersonalBackpack();
+        if (BackpackUtil.UUIDEquals(personalBackpack, uuid)) return true;
+
+        if (player.openContainer instanceof ContainerAdvanced container) {
+            BackpackSave openBackpack = container.getBackpackSave();
+            return openBackpack != null && BackpackUtil.UUIDEquals(openBackpack.getUUID(), uuid);
+        }
+
+        return false;
+    }
+
+    private boolean isValidUUID(String value) {
+        try {
+            UUID.fromString(value);
+            return true;
+        } catch (IllegalArgumentException | NullPointerException e) {
+            return false;
+        }
     }
 }

--- a/src/main/java/de/eydamos/backpack/network/message/MessageBackpackInfoRequest.java
+++ b/src/main/java/de/eydamos/backpack/network/message/MessageBackpackInfoRequest.java
@@ -3,6 +3,7 @@ package de.eydamos.backpack.network.message;
 import java.util.UUID;
 
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
@@ -59,11 +60,11 @@ public class MessageBackpackInfoRequest implements IMessage, IMessageHandler<Mes
     }
 
     private boolean canRequestBackpackInfo(EntityPlayerMP player, String uuid) {
-        for (ItemStack stack : player.inventory.mainInventory) {
-            if (BackpackUtil.UUIDEquals(stack, uuid)) return true;
-        }
-        for (ItemStack stack : player.inventory.armorInventory) {
-            if (BackpackUtil.UUIDEquals(stack, uuid)) return true;
+        for (Object slotObject : player.openContainer.inventorySlots) {
+            Slot slot = (Slot) slotObject;
+            if (slot != null && BackpackUtil.UUIDEquals(slot.getStack(), uuid)) {
+                return true;
+            }
         }
 
         ItemStack personalBackpack = new PlayerSave(player).getPersonalBackpack();

--- a/src/main/java/de/eydamos/backpack/network/message/MessagePersonalBackpack.java
+++ b/src/main/java/de/eydamos/backpack/network/message/MessagePersonalBackpack.java
@@ -60,10 +60,12 @@ public class MessagePersonalBackpack implements IMessage, IMessageHandler<Messag
             PlayerSave playerSave = new PlayerSave(playerUUID);
             ItemStack backpack = playerSave.getPersonalBackpack();
             if (backpack != null) {
+                // Only the requester needs their own backpack UUID
+                boolean self = target == ctx.getServerHandler().playerEntity;
                 returnMessage = new MessagePersonalBackpack(
                         playerUUID,
                         backpack.getItemDamage(),
-                        new BackpackSave(backpack).getUUID());
+                        self ? new BackpackSave(backpack).getUUID() : "");
             } else {
                 returnMessage = new MessagePersonalBackpack(playerUUID);
             }

--- a/src/main/java/de/eydamos/backpack/network/message/MessagePersonalBackpack.java
+++ b/src/main/java/de/eydamos/backpack/network/message/MessagePersonalBackpack.java
@@ -43,13 +43,14 @@ public class MessagePersonalBackpack implements IMessage, IMessageHandler<Messag
     public IMessage onMessage(MessagePersonalBackpack message, MessageContext ctx) {
         IMessage returnMessage = null;
         if (BackpackUtil.isServerSide()) {
+            String playerUUID = ctx.getServerHandler().playerEntity.getUniqueID().toString();
 
-            PlayerSave playerSave = new PlayerSave(message.playerUUID);
+            PlayerSave playerSave = new PlayerSave(playerUUID);
             ItemStack backpack = playerSave.getPersonalBackpack();
             if (backpack != null) {
-                returnMessage = new MessagePersonalBackpack(message.playerUUID, backpack.getItemDamage());
+                returnMessage = new MessagePersonalBackpack(playerUUID, backpack.getItemDamage());
             } else {
-                returnMessage = new MessagePersonalBackpack(message.playerUUID);
+                returnMessage = new MessagePersonalBackpack(playerUUID);
             }
         } else {
             // Client

--- a/src/main/java/de/eydamos/backpack/network/message/MessagePersonalBackpack.java
+++ b/src/main/java/de/eydamos/backpack/network/message/MessagePersonalBackpack.java
@@ -1,5 +1,8 @@
 package de.eydamos.backpack.network.message;
 
+import java.util.UUID;
+
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 
 import cpw.mods.fml.common.network.ByteBufUtils;
@@ -43,7 +46,11 @@ public class MessagePersonalBackpack implements IMessage, IMessageHandler<Messag
     public IMessage onMessage(MessagePersonalBackpack message, MessageContext ctx) {
         IMessage returnMessage = null;
         if (BackpackUtil.isServerSide()) {
-            String playerUUID = ctx.getServerHandler().playerEntity.getUniqueID().toString();
+            EntityPlayer target = resolveOnlinePlayer(ctx, message.playerUUID);
+            if (target == null) {
+                return null;
+            }
+            String playerUUID = target.getUniqueID().toString();
 
             PlayerSave playerSave = new PlayerSave(playerUUID);
             ItemStack backpack = playerSave.getPersonalBackpack();
@@ -57,5 +64,13 @@ public class MessagePersonalBackpack implements IMessage, IMessageHandler<Messag
             EventHandlerClientOnly.updateTag(message.playerUUID, message.backpackDamage);
         }
         return returnMessage;
+    }
+
+    private EntityPlayer resolveOnlinePlayer(MessageContext ctx, String uuid) {
+        try {
+            return ctx.getServerHandler().playerEntity.worldObj.func_152378_a(UUID.fromString(uuid));
+        } catch (IllegalArgumentException | NullPointerException e) {
+            return null;
+        }
     }
 }

--- a/src/main/java/de/eydamos/backpack/network/message/MessageRecipe.java
+++ b/src/main/java/de/eydamos/backpack/network/message/MessageRecipe.java
@@ -4,16 +4,22 @@ import java.util.ArrayList;
 
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.Container;
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.ItemStack;
 
 import cpw.mods.fml.common.network.ByteBufUtils;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import de.eydamos.backpack.inventory.container.Boundaries;
 import de.eydamos.backpack.inventory.container.ContainerWorkbenchBackpack;
+import de.eydamos.backpack.inventory.slot.SlotPhantom;
 import de.eydamos.backpack.nei.OverlayHandlerBackpack.SlotStack;
 import io.netty.buffer.ByteBuf;
 
 public class MessageRecipe implements IMessage, IMessageHandler<MessageRecipe, IMessage> {
+
+    private static final int MAX_RECIPE_SLOTS = 9;
 
     protected ArrayList<SlotStack> recipeList;
 
@@ -28,6 +34,9 @@ public class MessageRecipe implements IMessage, IMessageHandler<MessageRecipe, I
     @Override
     public void fromBytes(ByteBuf buffer) {
         int max = buffer.readInt();
+        if (max < 0 || max > MAX_RECIPE_SLOTS) {
+            return;
+        }
         for (int i = 0; i < max; i++) {
             recipeList.add(new SlotStack(ByteBufUtils.readItemStack(buffer), buffer.readInt()));
         }
@@ -48,11 +57,30 @@ public class MessageRecipe implements IMessage, IMessageHandler<MessageRecipe, I
 
         Container container = entityPlayer.openContainer;
 
-        if (container instanceof ContainerWorkbenchBackpack) {
-            ((ContainerWorkbenchBackpack) container).clearCraftMatrix();
+        if (container instanceof ContainerWorkbenchBackpack workbench) {
+            int from = workbench.getBoundary(Boundaries.CRAFTING);
+            int to = workbench.getBoundary(Boundaries.CRAFTING_END);
+            if (from < 0 || to < from) {
+                return null;
+            }
+
+            workbench.clearCraftMatrix();
 
             for (SlotStack slotStack : message.recipeList) {
-                container.putStackInSlot(slotStack.getSlot(), slotStack.getStack());
+                int slotIndex = slotStack.getSlot();
+                if (slotIndex < from || slotIndex >= to || slotIndex >= workbench.inventorySlots.size()) {
+                    continue;
+                }
+                Slot slot = workbench.getSlot(slotIndex);
+                if (!(slot instanceof SlotPhantom)) {
+                    continue;
+                }
+                ItemStack stack = slotStack.getStack();
+                if (stack != null) {
+                    stack = stack.copy();
+                    stack.stackSize = 1;
+                }
+                workbench.putStackInSlot(slotIndex, stack);
             }
         }
 

--- a/src/main/java/de/eydamos/backpack/saves/BackpackSave.java
+++ b/src/main/java/de/eydamos/backpack/saves/BackpackSave.java
@@ -39,7 +39,7 @@ public class BackpackSave extends AbstractSave {
         } else {
             if (backpack.getItem() instanceof ItemBackpackBase) {
                 load(NBTItemStackUtil.getString(backpack, Constants.NBT.UID));
-                if (force || getType() == 0 || getSize() <= 0) {
+                if (force || getType() != BackpackUtil.getType(backpack) || getSize() != getSize(backpack)) {
                     initialize(backpack);
                 }
             }

--- a/src/main/java/de/eydamos/backpack/saves/BackpackSave.java
+++ b/src/main/java/de/eydamos/backpack/saves/BackpackSave.java
@@ -39,7 +39,7 @@ public class BackpackSave extends AbstractSave {
         } else {
             if (backpack.getItem() instanceof ItemBackpackBase) {
                 load(NBTItemStackUtil.getString(backpack, Constants.NBT.UID));
-                if (force) {
+                if (force || getType() == 0 || getSize() <= 0) {
                     initialize(backpack);
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25616

~Creating PR as draft so player can test it with their setup.~

Had troubles with repro but user in linked issue confirmed the fix work.

Changes related to the issue:
- Fix backpacks with invalid metadata on save/open
- Fix backpacks disappearing when closed

Changes unrelated (sidequests on a bunch of major bug/security issues):
- Prevent NEI recipe packets from writing arbitrary client-provided stacks into server inventory slots.
- Validate backpack/player save filenames as UUIDs before loading, saving, or deleting save data.
- Restrict backpack slot-usage info requests to backpacks owned by or currently opened by the requesting player.
- Use the packet sender’s UUID for personal backpack sync instead of trusting a client-supplied UUID.
- Add bounds checks for workbench backpack slot clicks.
- Guard InvTweaks container section creation against missing or invalid boundaries.
- Properly log some save errors
