### PR TITLE
Flush the open container before reading the backpack save

### DIFF
--- a/src/main/java/de/eydamos/backpack/helper/GuiHelper.java
+++ b/src/main/java/de/eydamos/backpack/helper/GuiHelper.java
@@ -70,31 +70,28 @@ public class GuiHelper {
     }
 
     /**
-     * Prepares containers and gui for rending backpack inventory window. TODO should have different from
-     * `displayBackpack` name because of code injection from different mod
-     * <a href="https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26484">issue</a> Should be renamed back
-     * after issue with mixins will be resolved
+     * Opens a backpack from its ItemStack, building the save and the inventory itself. Use this instead of
+     * {@link #displayBackpack}: it closes an already open container first, so the save is never read before that
+     * container has flushed.
+     * <p>
+     * TODO Kept under a separate name because Backhand mixes into {@link #displayBackpack} by bare method name. Once
+     * Backhand targets this method instead, fold the other overload into it, see
+     * <a href="https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26484">modpack issue 26484</a>.
      *
-     * @param backpack     ItemStack for backpack item.
-     * @param entityPlayer Player object.
+     * @param backpack     ItemStack of the backpack to open.
+     * @param entityPlayer Player to open it for.
      */
     public static void displayBackpackSelfSufficient(ItemStack backpack, EntityPlayerMP entityPlayer) {
 
         if (!isDimensionAllowed(entityPlayer)) return;
 
+        // flush the open container first, or closing it later writes its stale contents back over the save
         prepare(entityPlayer);
 
-        BackpackSave backpackSave = new BackpackSave(backpack);
-        IInventory inventory = ItemBackpackBase.getInventory(backpack, entityPlayer);
-
-        MessageOpenBackpack message = new MessageOpenBackpack(backpackSave, inventory, entityPlayer.currentWindowId);
-        Backpack.packetHandler.networkWrapper.sendTo(message, entityPlayer);
-
-        Container container = FactoryBackpack
-                .getContainer(backpackSave, new IInventory[] { entityPlayer.inventory, inventory }, entityPlayer);
-        openContainer(container, entityPlayer);
-
-        BackpackUtil.playOpenSound(entityPlayer);
+        displayBackpack(
+                new BackpackSave(backpack),
+                ItemBackpackBase.getInventory(backpack, entityPlayer),
+                entityPlayer);
     }
 
     public static void displayPersonalSlot(EntityPlayerMP entityPlayer) {

--- a/src/main/java/de/eydamos/backpack/item/ItemBackpackBase.java
+++ b/src/main/java/de/eydamos/backpack/item/ItemBackpackBase.java
@@ -124,10 +124,7 @@ public class ItemBackpackBase extends Item implements ActivatableFromInventorySe
 
         // when the player is not sneaking
         if (!entityPlayer.isSneaking() && !ConfigurationBackpack.OPEN_ONLY_PERSONAL_BACKPACK) {
-            GuiHelper.displayBackpack(
-                    new BackpackSave(itemStack),
-                    getInventory(itemStack, entityPlayer),
-                    (EntityPlayerMP) entityPlayer);
+            GuiHelper.displayBackpackSelfSufficient(itemStack, (EntityPlayerMP) entityPlayer);
         }
         return itemStack;
     }

--- a/src/main/java/de/eydamos/backpack/network/message/MessageOpenGui.java
+++ b/src/main/java/de/eydamos/backpack/network/message/MessageOpenGui.java
@@ -7,7 +7,6 @@ import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;
 import de.eydamos.backpack.helper.GuiHelper;
-import de.eydamos.backpack.item.ItemBackpackBase;
 import de.eydamos.backpack.misc.Constants;
 import de.eydamos.backpack.saves.BackpackSave;
 import de.eydamos.backpack.saves.PlayerSave;
@@ -41,14 +40,10 @@ public class MessageOpenGui implements IMessage, IMessageHandler<MessageOpenGui,
                 PlayerSave playerSave = new PlayerSave(entityPlayer);
                 ItemStack backpack = playerSave.getPersonalBackpack();
                 if (backpack != null) {
-                    BackpackSave backpackSave = new BackpackSave(backpack);
-                    GuiHelper.displayBackpack(
-                            backpackSave,
-                            ItemBackpackBase.getInventory(backpack, entityPlayer),
-                            entityPlayer);
+                    GuiHelper.displayBackpackSelfSufficient(backpack, entityPlayer);
                     // Set the open flag after displaying: closing a previously open backpack
                     // clears it, so setting it earlier would be undone and the GUI would close.
-                    new PlayerSave(entityPlayer).setPersonalBackpackOpen(backpackSave.getUUID());
+                    new PlayerSave(entityPlayer).setPersonalBackpackOpen(BackpackSave.getUUID(backpack));
                 }
             }
             case Constants.Guis.OPEN_PERSONAL_SLOT -> GuiHelper.displayPersonalSlot(entityPlayer);


### PR DESCRIPTION
## Summary
`onItemRightClick` and the personal backpack tab built the `BackpackSave` as a call argument, so the
save was read before `prepare()` closed and flushed an already open container. Reopening the backpack
could then show its pre-open contents.


## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge


fixes https://github.com/GTNewHorizons/Dupes-Exploits-GTNH/issues/256